### PR TITLE
Hotfix/movement status (w/ signed-off-by)

### DIFF
--- a/src/emc/tp/blendmath.c
+++ b/src/emc/tp/blendmath.c
@@ -1205,8 +1205,8 @@ int blendCheckConsume(BlendParameters * const param,
     double L_prev = prev_tc->target - points->trim1;
     double prev_seg_time = L_prev / param->v_plan;
 
-    bool need_prev = prev_tc->blend_prev || prev_tc->atspeed;
-    param->consume = (prev_seg_time < gap_cycles * prev_tc->cycle_time && !need_prev);
+    bool can_consume = tcCanConsume(prev_tc);
+    param->consume = (prev_seg_time < gap_cycles * prev_tc->cycle_time && can_consume);
     if (param->consume) {
         tp_debug_print("consuming prev line, L_prev = %g\n",
                 L_prev);

--- a/src/emc/tp/tc.c
+++ b/src/emc/tp/tc.c
@@ -126,6 +126,25 @@ int tcGetIntersectionPoint(TC_STRUCT const * const prev_tc,
     return TP_ERR_OK;
 }
 
+
+/**
+ * Check if a segment can be consumed without disrupting motion or synced IO.
+ */
+int tcCanConsume(TC_STRUCT const * const tc)
+{
+    if (!tc) {
+        return false;
+    }
+
+    if (tc->syncdio.anychanged || tc->blend_prev || tc->atspeed) {
+        //TODO add other conditions here (for any segment that should not be consumed by blending
+        return false;
+    }
+
+    return true;
+
+}
+
 /**
  * Find the geometric tangent vector to a helical arc.
  * Unlike the acceleration vector, the result of this calculation is a vector

--- a/src/emc/tp/tc.h
+++ b/src/emc/tp/tc.h
@@ -34,20 +34,16 @@ int tcGetStartTangentUnitVector(TC_STRUCT const * const tc, PmCartesian * const 
 int tcGetIntersectionPoint(TC_STRUCT const * const prev_tc,
         TC_STRUCT const * const tc, PmCartesian * const point);
 
-int pmCircleFromPoints(PmCircle * const arc, PmCartesian const * const start,
-        PmCartesian const * const middle, PmCartesian const * const end,
-        double radius, PmCartesian * const circ_start, PmCartesian * const circ_end);
-
-int pmCircleFromLines(PmCircle * const arc, PmCartLine const * const line1,
-        PmCartLine const * const line2, double radius,
-        double blend_dist, double center_dist, PmCartesian * const start, PmCartesian * const end);
+int tcCanConsume(TC_STRUCT const * const tc);
 
 int tcSetTermCond(TC_STRUCT * const tc, int term_cond);
+
 int tcConnectBlendArc(TC_STRUCT * const prev_tc, TC_STRUCT * const tc,
         PmCartesian const * const circ_start,
         PmCartesian const * const circ_end);
 
 int tcIsBlending(TC_STRUCT * const tc);
+
 
 int tcFindBlendTolerance(TC_STRUCT const * const prev_tc,
         TC_STRUCT const * const tc, double * const T_blend, double * const nominal_tolerance);


### PR DESCRIPTION
tpHandleEmptyQueue now explicitly sets status flags in tp and
emcmotStatus to the appropriate defaults. This should prevent spurious
non-zero values from appearing in current_vel and similar status fields
when the motion queue is empty. This was likely an overlooked regression
from 2.6 due to the major refactor introduced with the new trajectory
planner.