### PR TITLE
tp: fix for pause during spindle synced motion regression from 2.6

### DIFF
--- a/src/emc/tp/tp.c
+++ b/src/emc/tp/tp.c
@@ -173,8 +173,13 @@ STATIC int tpGetMachineActiveLimit(double * const act_limit, PmCartesian const *
 STATIC double tpGetFeedScale(TP_STRUCT const * const tp,
         TC_STRUCT const * const tc) {
     //All reasons to disable feed override go here
-    if (tp->pausing || tp->aborting) {
-        tc_debug_print("pausing or aborting\n");
+    bool pausing = tp->pausing && tc->synchronized == TC_SYNC_NONE;
+    bool aborting = tp->aborting;
+    if (pausing)  {
+        tc_debug_print("pausing\n");
+        return 0.0;
+    } else if (aborting) {
+        tc_debug_print("aborting\n");
         return 0.0;
     } else if (tc->synchronized == TC_SYNC_POSITION ) {
         return 1.0;


### PR DESCRIPTION
This fix restores 2.6's handling of pause during a spindle-synced move (i.e. don't pause during a spindle-synced move).