### PR TITLE
fix rs274ngc_pre compilation with new boost+gcc

### DIFF
--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -130,7 +130,7 @@ Interp::Interp()
 	// since interp.init() may be called repeatedly this would create a new
 	// wrapper instance on every init(), abandoning the old one and all user attributes
 	// tacked onto it, so make sure this is done exactly once
-	_setup.pythis =  boost::python::object(boost::cref(this));
+	_setup.pythis = boost::python::object(boost::cref(*this));
 	
 	// alias to 'interpreter.this' for the sake of ';py, .... ' comments
 	// besides 'this', eventually use proper instance names to handle


### PR DESCRIPTION
with boost-1.58 the error message was
emc/rs274ngc/rs274ngc_pre.cc:133:57: error: use of deleted function 'void boost::cref(const T&amp;&amp;) [with T = Interp*]'
  _setup.pythis =  boost::python::object(boost::cref(this));

/usr/include/boost/core/ref.hpp:179:24: error: declared here
template&lt;class T&gt; void cref(T const&amp;&amp;) BOOST_REF_DELETE;

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>